### PR TITLE
chore(release): restore published v0.3.8 source

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "saorsa-mls"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
 rust-version = "1.88.0"
 authors = ["Saorsa Labs Limited <saorsalabs@gmail.com>"]

--- a/src/treekem_group.rs
+++ b/src/treekem_group.rs
@@ -857,6 +857,39 @@ impl TreeKemGroup {
         self.tree.active_leaf_count()
     }
 
+    /// Signature verifying key bytes for the active member at `leaf`.
+    ///
+    /// Returns `None` for blanked or out-of-range leaves. This exposes only
+    /// public leaf credential material and is intended for applications that
+    /// maintain an external roster and need to verify that a roster identity is
+    /// bound to the TreeKEM leaf they are about to remove.
+    #[must_use]
+    pub fn leaf_verifying_key(&self, leaf: u32) -> Option<Vec<u8>> {
+        self.tree.leaf_verifying_key(leaf).map(<[u8]>::to_vec)
+    }
+
+    /// KEM agreement public key bytes for the active member at `leaf`.
+    ///
+    /// Returns `None` for blanked or out-of-range leaves. Together with
+    /// [`Self::leaf_verifying_key`], this is the stable public identity pair
+    /// used by TreeKEM to match re-derived key packages to leaves.
+    #[must_use]
+    pub fn leaf_agreement_key(&self, leaf: u32) -> Option<Vec<u8>> {
+        self.tree
+            .leaf(leaf)
+            .map(|data| data.key_package.agreement_key.clone())
+    }
+
+    /// Find the active leaf whose stable public keys match `key_package`.
+    ///
+    /// This intentionally matches only the verifying and agreement public keys:
+    /// ML-DSA signing is randomized, so re-derived key packages may not be
+    /// byte-identical even though they represent the same member identity.
+    #[must_use]
+    pub fn find_leaf_by_key_package(&self, key_package: &KeyPackage) -> Option<u32> {
+        self.tree.find_leaf(key_package)
+    }
+
     fn reconstruct_signature_for(suite: CipherSuite, bytes: &[u8]) -> Result<Signature> {
         if suite.uses_slh_dsa() {
             let sig = SlhDsaSignature::from_bytes(suite.slh_dsa_variant()?, bytes)
@@ -1198,6 +1231,36 @@ mod tests {
             bob_group.decrypt_message(&ct),
             Err(MlsError::InvalidEpoch { .. })
         ));
+    }
+
+    #[test]
+    fn leaf_public_key_inspection_reports_only_active_leaves() {
+        let suite = CipherSuite::default();
+        let alice = identity(suite);
+        let bob = identity(suite);
+        let mut alice_group = TreeKemGroup::create(b"room".to_vec(), alice).unwrap();
+        let (_c, w) = alice_group.add_member(&bob.key_package).unwrap();
+        let bob_group = TreeKemGroup::from_welcome(&w, bob.clone()).unwrap();
+        let bob_leaf = bob_group.own_leaf().unwrap();
+
+        assert_eq!(
+            alice_group.leaf_verifying_key(bob_leaf).as_deref(),
+            Some(bob.key_package.verifying_key.as_slice())
+        );
+        assert_eq!(
+            alice_group.leaf_agreement_key(bob_leaf).as_deref(),
+            Some(bob.key_package.agreement_key.as_slice())
+        );
+        assert_eq!(
+            alice_group.find_leaf_by_key_package(&bob.key_package),
+            Some(bob_leaf)
+        );
+        assert!(alice_group.leaf_verifying_key(u32::MAX).is_none());
+        assert!(alice_group.leaf_agreement_key(u32::MAX).is_none());
+
+        alice_group.remove_member(bob_leaf).unwrap();
+        assert!(alice_group.leaf_verifying_key(bob_leaf).is_none());
+        assert!(alice_group.leaf_agreement_key(bob_leaf).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- restores the exact source already published to crates.io as `saorsa-mls 0.3.8`
- adds the published TreeKEM leaf public-key inspection API and its test
- advances the canonical manifest from `0.3.7` to the published `0.3.8`

## Provenance
The crates.io archive records source commit `0dca25c49671758147dba18a617864f0b4f5f8a2`, but that object is no longer reachable from the canonical GitHub repository. A recursive source comparison against the downloaded crate showed only these differences from `main`:

1. `Cargo.toml`: `0.3.7` → `0.3.8`
2. `src/treekem_group.rs`: the three public leaf-inspection methods and their test restored here

After this patch, both files are byte-identical to `Cargo.toml.orig` and `src/treekem_group.rs` in the published crate archive; every other shared source file already matched.

Published crate archive SHA-256: `931d3dcde2afb4d1f8db4364aa43ac7db347e6350e531b65ff15466375af2196`.

## Verification
- `cargo fmt --all -- --check`
- `cargo test --all-features --no-fail-fast` (all passed; one pre-existing ignored test)
- `cargo clippy --all-targets --all-features -- -D warnings`
- exact byte comparison against the downloaded crates.io `0.3.8` source

## Follow-up after merge
Create tag and GitHub release `v0.3.8` at the merged commit. The existing release workflow will attempt to republish the immutable crates.io version and is therefore expected to report “already uploaded”; crates.io must not be republished or yanked for this provenance repair.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Restores the published 0.3.8 package version and adds public APIs for inspecting and locating active TreeKEM leaves.
- Advances the crate manifest from 0.3.7 to 0.3.8.
- Exposes stable verifying and agreement keys for active leaves.
- Adds key-package-to-leaf lookup and coverage for active, removed, and out-of-range leaves.

<h3>Confidence Score: 4/5</h3>

The duplicate-identity lookup ambiguity should be fixed before merging because callers can target the wrong active leaf for roster association or removal.

The new public lookup promises identity-to-leaf matching while delegating to a first-match search, and existing insertion paths permit multiple active leaves with the same matching key pair.

**Files Needing Attention:** src/treekem_group.rs

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Cargo.toml | Updates the canonical crate version to 0.3.8 consistently with the intended release tag. |
| src/treekem_group.rs | Adds public leaf inspection APIs and tests, but key-package lookup is ambiguous when duplicate identity key pairs occupy active leaves. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/treekem_group.rs:889-891
**First-match leaf lookup is ambiguous**

When two active members have the same verifying and agreement keys, `find_leaf_by_key_package` returns the lower-index match because insertion does not enforce uniqueness, causing roster association or removal to target the wrong active leaf.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): restore published v0.3.8..."](https://github.com/saorsa-labs/saorsa-mls/commit/5355ab6aceff8d176849570b94264e545ee4c3a9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49619653)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->